### PR TITLE
Coinbase api changes 2023 nov 13 to 2023 dec 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+/ToDo.txt

--- a/Coinbase.AdvancedTrade.Test/MockDataHelper.cs
+++ b/Coinbase.AdvancedTrade.Test/MockDataHelper.cs
@@ -408,8 +408,19 @@ namespace Coinbase.AdvancedTradeTest.Helpers
         }
 
 
-
-
+        /// <summary>
+        /// Gets mock server time data for testing purposes.
+        /// </summary>
+        /// <returns>A mock ServerTime object.</returns>
+        public static ServerTime GetMockServerTime()
+        {
+            return new ServerTime
+            {
+                Iso = "2023-11-28T00:00:22Z",
+                EpochSeconds = "1701129622",
+                EpochMillis = "1701129622115"
+            };
+        }
 
 
 

--- a/Coinbase.AdvancedTrade.Test/MockDataHelper.cs
+++ b/Coinbase.AdvancedTrade.Test/MockDataHelper.cs
@@ -1,5 +1,5 @@
 ﻿using Coinbase.AdvancedTrade.Models;
-
+using System.Text.Json;
 
 namespace Coinbase.AdvancedTradeTest.Helpers
 {
@@ -419,6 +419,23 @@ namespace Coinbase.AdvancedTradeTest.Helpers
                 Iso = "2023-11-28T00:00:22Z",
                 EpochSeconds = "1701129622",
                 EpochMillis = "1701129622115"
+            };
+        }
+
+
+
+        public static EditOrderPreviewResult GetMockEditOrderPreviewResponse()
+        {
+            return new EditOrderPreviewResult
+            {
+                Slippage = "0.01", 
+                OrderTotal = "10500", 
+                CommissionTotal = "50", 
+                QuoteSize = "10000", 
+                BaseSize = "0.5", 
+                BestBid = "10400", 
+                BestAsk = "10600",
+                AverageFilledPrice = "10500" 
             };
         }
 

--- a/Coinbase.AdvancedTrade.Test/MockSetupHelper.cs
+++ b/Coinbase.AdvancedTrade.Test/MockSetupHelper.cs
@@ -95,6 +95,13 @@ namespace Coinbase.AdvancedTradeTest.Helpers
             mock.Setup(o => o.CreateStopLimitOrderGTDAsync(It.IsAny<string>(), It.IsAny<OrderSide>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>()))
                 .ReturnsAsync(fixedOrderId);
 
+            mock.Setup(o => o.EditOrderAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+
+            mock.Setup(o => o.EditOrderPreviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(MockDataHelper.GetMockEditOrderPreviewResponse());
+
+
             return mock;
         }
 

--- a/Coinbase.AdvancedTrade.Test/MockSetupHelper.cs
+++ b/Coinbase.AdvancedTrade.Test/MockSetupHelper.cs
@@ -108,5 +108,18 @@ namespace Coinbase.AdvancedTradeTest.Helpers
 
             return mock;
         }
+
+        // Helper method to initialize a mock of ICommonManager
+        public static Mock<ICommonManager> InitializeCommonMock()
+        {
+            var mock = new Mock<ICommonManager>();
+
+            // Set up mock behavior for GetCoinbaseServerTimeAsync
+            mock.Setup(c => c.GetCoinbaseServerTimeAsync())
+                .ReturnsAsync(MockDataHelper.GetMockServerTime());
+
+            return mock;
+        }
+
     }
 }

--- a/Coinbase.AdvancedTrade.Test/TestBase.cs
+++ b/Coinbase.AdvancedTrade.Test/TestBase.cs
@@ -31,7 +31,8 @@ namespace Coinbase.AdvancedTradeTest
                     MockSetupHelper.InitializeAccountsMock().Object,
                     MockSetupHelper.InitializeProductsMock().Object,
                     MockSetupHelper.InitializeOrdersMock().Object,
-                    MockSetupHelper.InitializeFeesMock().Object);
+                    MockSetupHelper.InitializeFeesMock().Object,
+                    MockSetupHelper.InitializeCommonMock().Object);
 
             _webSocketManager = _coinbaseClient?.WebSocket;
         }

--- a/Coinbase.AdvancedTrade.Test/TestCommon.cs
+++ b/Coinbase.AdvancedTrade.Test/TestCommon.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+using Coinbase.AdvancedTrade.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Coinbase.AdvancedTradeTest
+{
+    [TestClass]
+    public class TestCommon : TestBase
+    {
+        [TestMethod]
+        [Description("Test to verify that the GetCoinbaseServerTimeAsync method returns valid server time details.")]
+        public async Task Test_Common_GetCoinbaseServerTimeAsync()
+        {
+            await ExecuteRateLimitedTest(async () =>
+            {
+                var serverTime = await _coinbaseClient!.Common.GetCoinbaseServerTimeAsync();
+
+                Assert.IsNotNull(serverTime, "Server Time should not be null.");
+                Assert.IsFalse(string.IsNullOrWhiteSpace(serverTime.Iso), "ISO time should not be null or whitespace.");
+                Assert.IsFalse(string.IsNullOrWhiteSpace(serverTime.EpochSeconds), "Epoch Seconds should not be null or whitespace.");
+                Assert.IsFalse(string.IsNullOrWhiteSpace(serverTime.EpochMillis), "Epoch Milliseconds should not be null or whitespace.");
+
+            });
+        }
+    }
+}

--- a/Coinbase.AdvancedTrade.Test/TestOrders.cs
+++ b/Coinbase.AdvancedTrade.Test/TestOrders.cs
@@ -83,5 +83,49 @@ namespace Coinbase.AdvancedTradeTest
         }
 
 
+
+        [TestMethod]
+        [Description("Test to verify that EditOrder successfully edits an existing order.")]
+        public async Task Test_Orders_EditOrderAsync()
+        {
+            await ExecuteRateLimitedTest(async () =>
+            {
+                string existingOrderId = "0b3273de-e901-4e4d-bbf6-ecb107578a3c";
+
+                string newPrice = "40500";
+                string? newSize = "0.0000393";
+
+                // Attempt to edit the order
+                var result = await _coinbaseClient!.Orders.EditOrderAsync(existingOrderId, newPrice, newSize);
+
+                // Assert that the edit operation was reported as successful
+                Assert.IsTrue(result, "Edit operation should be reported as successful.");
+            });
+        }
+
+
+        [TestMethod]
+        [Description("Test to verify that EditOrderPreview successfully previewed the edit of an existing order.")]
+        public async Task Test_Orders_EditOrderPreviewAsync()
+        {
+            await ExecuteRateLimitedTest(async () =>
+            {
+                string existingOrderId = "0b3273de-e901-4e4d-bbf6-ecb107578a3c";
+
+                string newPrice = "40500";
+                string newSize = "0.0000393"; 
+
+                var result = await _coinbaseClient!.Orders.EditOrderPreviewAsync(existingOrderId, newPrice, newSize);
+
+                Assert.IsNotNull(result, "Preview result should not be null.");
+                Assert.IsFalse(string.IsNullOrWhiteSpace(result.OrderTotal), "OrderTotal should have a value.");
+                Assert.IsFalse(string.IsNullOrWhiteSpace(result.CommissionTotal), "CommissionTotal should have a value.");
+      
+            });
+        }
+
+
+
+
     }
 }

--- a/Coinbase.AdvancedTrade.sln
+++ b/Coinbase.AdvancedTrade.sln
@@ -7,21 +7,26 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Coinbase.AdvancedTrade", "C
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Coinbase.AdvancedTrade.Tests", "Coinbase.AdvancedTrade.Test\Coinbase.AdvancedTrade.Tests.csproj", "{20D5F9A9-9F4D-4EF7-BB99-ECBE3E3C7A97}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebSocketCandlesTestApp", "WebSocketTestApp\WebSocketCandlesTestApp.csproj", "{D5F16F96-48CE-458E-A1C6-8BE49A4C5B05}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebSocketCandlesTestApp", "WebSocketTestApp\WebSocketCandlesTestApp.csproj", "{D5F16F96-48CE-458E-A1C6-8BE49A4C5B05}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebSocketHeartbeatTestApp", "WebSocketHeartbeatTestApp\WebSocketHeartbeatTestApp.csproj", "{EE7B5B64-BBCD-4146-8D0F-376617721789}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebSocketHeartbeatTestApp", "WebSocketHeartbeatTestApp\WebSocketHeartbeatTestApp.csproj", "{EE7B5B64-BBCD-4146-8D0F-376617721789}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebSocketMarketTradesTestApp", "WebSocketMarketTradesTestApp\WebSocketMarketTradesTestApp.csproj", "{CE222C8F-B1A2-4F0A-A36F-5A5C454C38D7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebSocketMarketTradesTestApp", "WebSocketMarketTradesTestApp\WebSocketMarketTradesTestApp.csproj", "{CE222C8F-B1A2-4F0A-A36F-5A5C454C38D7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebSocketStatusTestApp", "WebSocketStatusTestApp\WebSocketStatusTestApp.csproj", "{44C1BDEE-612B-4872-B7F9-3A1499FEA731}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebSocketStatusTestApp", "WebSocketStatusTestApp\WebSocketStatusTestApp.csproj", "{44C1BDEE-612B-4872-B7F9-3A1499FEA731}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebSocketTickerTestApp", "WebSocketTickerTestApp\WebSocketTickerTestApp.csproj", "{4EED7C8C-1F0A-4887-84A8-A70FF61B89C5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebSocketTickerTestApp", "WebSocketTickerTestApp\WebSocketTickerTestApp.csproj", "{4EED7C8C-1F0A-4887-84A8-A70FF61B89C5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebSocketTickerBatchTestApp", "WebSocketTickerBatchTestApp\WebSocketTickerBatchTestApp.csproj", "{372C7CD7-ABEF-4587-B3D1-95D55E55138F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebSocketTickerBatchTestApp", "WebSocketTickerBatchTestApp\WebSocketTickerBatchTestApp.csproj", "{372C7CD7-ABEF-4587-B3D1-95D55E55138F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebSocketLevel2TestApp", "WebSocketLevel2TestApp\WebSocketLevel2TestApp.csproj", "{2C902B47-52DB-4EFF-8BD5-BECEC2656CFA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebSocketLevel2TestApp", "WebSocketLevel2TestApp\WebSocketLevel2TestApp.csproj", "{2C902B47-52DB-4EFF-8BD5-BECEC2656CFA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebSocketUserTestApp", "WebSocketUserTestApp\WebSocketUserTestApp.csproj", "{3648ED4D-CD32-44ED-B5B3-482A8AE54287}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebSocketUserTestApp", "WebSocketUserTestApp\WebSocketUserTestApp.csproj", "{3648ED4D-CD32-44ED-B5B3-482A8AE54287}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5B03447D-8DFB-44A0-8D96-C2F56DFC9167}"
+	ProjectSection(SolutionItems) = preProject
+		ToDo.txt = ToDo.txt
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Coinbase.AdvancedTrade/CoinbaseClient.cs
+++ b/Coinbase.AdvancedTrade/CoinbaseClient.cs
@@ -29,6 +29,11 @@ namespace Coinbase.AdvancedTrade
         public IFeesManager Fees { get; }
 
         /// <summary>
+        /// Gets the common manager, responsible for common-related operations.
+        /// </summary>
+        public ICommonManager Common { get; }
+
+        /// <summary>
         /// Gets the WebSocket manager, responsible for managing WebSocket connections.
         /// </summary>
         public WebSocketManager? WebSocket { get; }
@@ -45,6 +50,7 @@ namespace Coinbase.AdvancedTrade
             Products = new ProductsManager(authenticator);
             Orders = new OrdersManager(authenticator);
             Fees = new FeesManager(authenticator);
+            Common = new CommonManager(authenticator);
             WebSocket = new WebSocketManager("wss://advanced-trade-ws.coinbase.com", apiKey, apiSecret);
         }
 
@@ -55,12 +61,13 @@ namespace Coinbase.AdvancedTrade
         /// <param name="products">The mock or stub products manager for testing.</param>
         /// <param name="orders">The mock or stub orders manager for testing.</param>
         /// <param name="fees">The mock or stub fees manager for testing.</param>
-        public CoinbaseClient(IAccountsManager accounts, IProductsManager products, IOrdersManager orders, IFeesManager fees)
+        public CoinbaseClient(IAccountsManager accounts, IProductsManager products, IOrdersManager orders, IFeesManager fees, ICommonManager common)
         {
             Accounts = accounts;
             Products = products;
             Orders = orders;
             Fees = fees;
+            Common = common;
         }
     }
 }

--- a/Coinbase.AdvancedTrade/ExchangeManagers/BaseManager.cs
+++ b/Coinbase.AdvancedTrade/ExchangeManagers/BaseManager.cs
@@ -49,6 +49,35 @@ namespace Coinbase.AdvancedTrade.ExchangeManagers
             }
         }
 
+
+        /// <summary>
+        /// Deserializes a dictionary into an object of specified type.
+        /// </summary>
+        /// <param name="response">The dictionary representing the JSON object structure.</param>
+        /// <typeparam name="T">The type of object to deserialize into.</typeparam>
+        /// <returns>The deserialized object of type T, or default if deserialization fails.</returns>
+        /// <exception cref="InvalidOperationException">Thrown if deserialization fails due to invalid operation.</exception>
+        /// <remarks>
+        /// This method converts the provided dictionary into a JSON string and then attempts to deserialize it into the specified type.
+        /// It's useful for reconstructing objects when the response is already parsed into a dictionary form.
+        /// If the dictionary does not represent a JSON structure compatible with type T, deserialization will fail.
+        /// </remarks>
+        protected static T? DeserializeDictionary<T>(Dictionary<string, object> response)
+        {
+            try
+            {
+                // Convert the response dictionary back to JSON string and then deserialize it.
+                string jsonString = JsonSerializer.Serialize(response);
+                return JsonSerializer.Deserialize<T>(jsonString);
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException("Failed to deserialize dictionary", ex);
+            }
+        }
+
+
+
         /// <summary>
         /// Extracts a double value from a dictionary based on a specified key.
         /// </summary>

--- a/Coinbase.AdvancedTrade/ExchangeManagers/CommonManager.cs
+++ b/Coinbase.AdvancedTrade/ExchangeManagers/CommonManager.cs
@@ -1,0 +1,38 @@
+﻿using Coinbase.AdvancedTrade.Interfaces;
+using Coinbase.AdvancedTrade.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Coinbase.AdvancedTrade.ExchangeManagers
+{
+    /// <summary>
+    /// Manages common activities, including server time retrieval, for the Coinbase Advanced Trade API.
+    /// </summary>
+    public class CommonManager : BaseManager, ICommonManager
+    {
+        /// <summary>
+        /// Initializes a new instance of the CommonManager class.
+        /// </summary>
+        /// <param name="authenticator">The Coinbase authenticator.</param>
+        public CommonManager(CoinbaseAuthenticator authenticator) : base(authenticator) { }
+
+        /// <inheritdoc/>
+        public async Task<ServerTime?> GetCoinbaseServerTimeAsync()
+        {
+            try
+            {
+                // Send an authenticated request to the Coinbase API to retrieve the server time.
+                var response = await _authenticator.SendAuthenticatedRequestAsync("GET", "/api/v3/brokerage/time", null) ?? new Dictionary<string, object>();
+
+                // Deserialize the response into a ServerTime object.
+                return DeserializeDictionary<ServerTime>(response);
+            }
+            catch (Exception ex)
+            {
+                // Wrap and rethrow exceptions to provide more context.
+                throw new InvalidOperationException("Failed to get server time", ex);
+            }
+        }
+    }
+}

--- a/Coinbase.AdvancedTrade/Interfaces/ICommonManager.cs
+++ b/Coinbase.AdvancedTrade/Interfaces/ICommonManager.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Coinbase.AdvancedTrade.Models;
+
+namespace Coinbase.AdvancedTrade.Interfaces
+{
+    public interface ICommonManager
+    {
+        /// <summary>
+        /// Asynchronously retrieves the current server time from Coinbase.
+        /// </summary>
+        /// <returns>The server time details including ISO 8601 formatted date and time,
+        /// number of seconds since Unix epoch, and number of milliseconds since Unix epoch,
+        /// or null if the information is not available.</returns>
+        Task<ServerTime?> GetCoinbaseServerTimeAsync();
+    }
+}

--- a/Coinbase.AdvancedTrade/Interfaces/IOrdersManager.cs
+++ b/Coinbase.AdvancedTrade/Interfaces/IOrdersManager.cs
@@ -113,5 +113,31 @@ namespace Coinbase.AdvancedTrade.Interfaces
         /// <param name="endTime">Expiration time for the order.</param>
         /// <returns>A task representing the operation. The task result contains the ID of the created order, or null if creation failed.</returns>
         Task<string?> CreateStopLimitOrderGTDAsync(string productId, OrderSide side, string baseSize, string limitPrice, string stopPrice, DateTime endTime);
+
+
+        /// <summary>
+        /// Asynchronously edits an existing order with a specified new size or new price.
+        /// Only limit orders with a time in force type of good-till-cancelled can be edited.
+        /// Note: Increasing the size or modifying the price will lose the original place in the order book.
+        /// </summary>
+        /// <param name="orderId">ID of the order to edit.</param>
+        /// <param name="price">New price for the order.</param>
+        /// <param name="size">New size for the order.</param>
+        /// <returns>A task representing the operation, returning true if the edit was successful, false otherwise.</returns>
+        Task<bool> EditOrderAsync(string orderId, string price, string size);
+
+        /// <summary>
+        /// Asynchronously simulates an edit of an existing order with a specified new size or new price to preview the result.
+        /// This allows you to see the potential impact of an edit before committing to it.
+        /// Only limit orders with a time in force type of good-till-cancelled can be previewed.
+        /// Note: This does not actually edit the order; it only simulates the edit to provide a preview.
+        /// </summary>
+        /// <param name="orderId">ID of the order to edit.</param>
+        /// <param name="price">New price for the order.</param>
+        /// <param name="size">New size for the order.</param>
+        /// <returns>A task representing the operation, returning true if the preview was successful, false otherwise.</returns>
+        Task<EditOrderPreviewResult> EditOrderPreviewAsync(string orderId, string price, string size);
+
+
     }
 }

--- a/Coinbase.AdvancedTrade/Models/EditOrderPreviewResult.cs
+++ b/Coinbase.AdvancedTrade/Models/EditOrderPreviewResult.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Text.Json.Serialization;
+
+namespace Coinbase.AdvancedTrade.Models
+{
+    /// <summary>
+    /// Represents the result from previewing an order edit within the Coinbase system.
+    /// </summary>
+    public class EditOrderPreviewResult
+    {
+        /// <summary>
+        /// Gets or sets the estimated slippage for the edited order.
+        /// </summary>
+        [JsonPropertyName("slippage")]
+        public string? Slippage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total order value after the edit.
+        /// </summary>
+        [JsonPropertyName("order_total")]
+        public string? OrderTotal { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total commission for the edited order.
+        /// </summary>
+        [JsonPropertyName("commission_total")]
+        public string? CommissionTotal { get; set; }
+
+        /// <summary>
+        /// Gets or sets the size of the order in quote currency after the edit.
+        /// </summary>
+        [JsonPropertyName("quote_size")]
+        public string? QuoteSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the size of the order in base currency after the edit.
+        /// </summary>
+        [JsonPropertyName("base_size")]
+        public string? BaseSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the best bid price available for the order after the edit.
+        /// </summary>
+        [JsonPropertyName("best_bid")]
+        public string? BestBid { get; set; }
+
+        /// <summary>
+        /// Gets or sets the best ask price available for the order after the edit.
+        /// </summary>
+        [JsonPropertyName("best_ask")]
+        public string? BestAsk { get; set; }
+
+        /// <summary>
+        /// Gets or sets the average price at which the order was filled after the edit.
+        /// </summary>
+        [JsonPropertyName("average_filled_price")]
+        public string? AverageFilledPrice { get; set; }
+    }
+}

--- a/Coinbase.AdvancedTrade/Models/Order.cs
+++ b/Coinbase.AdvancedTrade/Models/Order.cs
@@ -124,6 +124,10 @@ namespace Coinbase.AdvancedTrade.Models
         // Indicates if the order is a liquidation order.
         [JsonPropertyName("is_liquidation")]
         public bool? IsLiquidation { get; set; }
+
+        // An array of the latest 5 edits per order.
+        [JsonPropertyName("edit_history")]
+        public List<EditHistoryEntry>? EditHistory { get; set; }
     }
 
     // Represents specific configurations for different types of orders.
@@ -213,5 +217,23 @@ namespace Coinbase.AdvancedTrade.Models
         [JsonPropertyName("end_time")]
         public DateTime EndTime { get; set; }
     }
+
+
+    // Represents an edit history entry for an order.
+    public class EditHistoryEntry
+    {
+        // The price associated with the edit.
+        [JsonPropertyName("price")]
+        public string? Price { get; set; }
+
+        // The size associated with the edit.
+        [JsonPropertyName("size")]
+        public string? Size { get; set; }
+
+        // The timestamp when the edit was accepted.
+        [JsonPropertyName("replace_accept_timestamp")]
+        public DateTime? ReplaceAcceptTimestamp { get; set; }
+    }
+
 
 }

--- a/Coinbase.AdvancedTrade/Models/ServerTime.cs
+++ b/Coinbase.AdvancedTrade/Models/ServerTime.cs
@@ -1,0 +1,28 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Coinbase.AdvancedTrade.Models
+{
+    /// <summary>
+    /// Represents the server time details.
+    /// </summary>
+    public class ServerTime
+    {
+        /// <summary>
+        /// Gets or sets the ISO 8601 formatted date and time.
+        /// </summary>
+        [JsonPropertyName("iso")]
+        public string? Iso { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of seconds since the Unix epoch as a string.
+        /// </summary>
+        [JsonPropertyName("epochSeconds")]
+        public string? EpochSeconds { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of milliseconds since the Unix epoch as a string.
+        /// </summary>
+        [JsonPropertyName("epochMillis")]
+        public string? EpochMillis { get; set; }
+    }
+}

--- a/Coinbase.AdvancedTrade/README.md
+++ b/Coinbase.AdvancedTrade/README.md
@@ -3,6 +3,9 @@
 
 This project provides a C# wrapper for the [Coinbase Advanced Trade API](https://docs.cloud.coinbase.com/advanced-trade-api), facilitating interactions with various advanced trading functionalities on Coinbase.
 
+**[View the Changelog](#changelog)** - See the detailed log of changes including updates, enhancements, and important notes.
+
+
 ## Overview
 The wrapper is organized into various namespaces, each serving a distinct purpose, covering the spectrum from data models to actual API interactions.
 
@@ -67,3 +70,16 @@ Fine-tuned enumerations like `OrderStatus`, `OrderType`, and others, ensuring cl
 
 ## Additional Information
 - **Models**: Detailed blueprints for entities such as `Account`, `Product`, `Order`, and `Candle`. These lay the groundwork for robust data representation when communicating with the Coinbase API.
+
+# Changelog
+
+## 2023-DEC-31 Update
+
+### Added
+- **Get UNIX Time** (Coinbase: 2023-DEC-06): Implemented feature (GetCoinbaseServerTimeAsync) to retrieve the current UNIX time from the Coinbase Advanced Trading API.
+- **Edit Order and Edit Order Preview** (Coinbase: 2023-NOV-13): Users can now edit and preview edits to orders, limited to certain conditions (IOrdersManager).
+
+### Notes on Non-Implemented Features
+- **Portfolios Feature (Coinbase: 2023-DEC-11)**: Currently in beta by Coinbase and not implemented in this wrapper. Intended for future updates.
+- **Converts Feature (Coinbase: 2023-NOV-27)**: Not implemented due to regional restrictions affecting testing capabilities.
+

--- a/Coinbase.AdvancedTrade/README.md
+++ b/Coinbase.AdvancedTrade/README.md
@@ -73,7 +73,7 @@ Fine-tuned enumerations like `OrderStatus`, `OrderType`, and others, ensuring cl
 
 # Changelog
 
-## 2023-DEC-31 Update
+## 2024-JAN-02 Update
 
 ### Added
 - **Get UNIX Time** (Coinbase: 2023-DEC-06): Implemented feature (GetCoinbaseServerTimeAsync) to retrieve the current UNIX time from the Coinbase Advanced Trading API.


### PR DESCRIPTION
 Added
- Get UNIX Time (Coinbase: 2023-DEC-06): Implemented feature (GetCoinbaseServerTimeAsync) to retrieve the current UNIX time from the Coinbase Advanced Trading API.
- Edit Order and Edit Order Preview (Coinbase: 2023-NOV-13): Users can now edit and preview edits to orders, limited to certain conditions (IOrdersManager).

Notes on Non-Implemented Features
-*Portfolios Feature (Coinbase: 2023-DEC-11): Currently in beta by Coinbase and not implemented in this wrapper. Intended for future updates.
- Converts Feature (Coinbase: 2023-NOV-27): Not implemented due to regional restrictions affecting testing capabilities.

