### PR TITLE
Restored ApiKeyType enum and updated CoinbaseClient constructor to support optional ApiKeyType for both Legacy and CDP keys. Updated test projects accordingly.

### DIFF
--- a/Coinbase.AdvancedTrade.IntegrationTests/TestBase.cs
+++ b/Coinbase.AdvancedTrade.IntegrationTests/TestBase.cs
@@ -24,6 +24,16 @@ namespace Coinbase.AdvancedTradeTest
                            ?? throw new InvalidOperationException("API Secret not found");
             _coinbaseClient = new CoinbaseClient(apiKey, apiSecret);
 
+
+            // Coinbase Legacy Keys
+            //var apiKey = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_KEY", EnvironmentVariableTarget.User)
+            //         ?? throw new InvalidOperationException("API Key not found");
+            //var apiSecret = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_SECRET", EnvironmentVariableTarget.User)
+            //           ?? throw new InvalidOperationException("API Secret not found");
+            //_coinbaseClient = new CoinbaseClient(apiKey: apiKey, apiSecret: apiSecret, apiKeyType: AdvancedTrade.Enums.ApiKeyType.Legacy);
+
+
+
             _webSocketManager = _coinbaseClient?.WebSocket;
         }
 

--- a/Coinbase.AdvancedTrade.IntegrationTests/TestOrderCreation.cs
+++ b/Coinbase.AdvancedTrade.IntegrationTests/TestOrderCreation.cs
@@ -25,7 +25,7 @@ namespace Coinbase.AdvancedTradeTest
             await ExecuteRateLimitedTest(async () =>
             {
                 Assert.IsNotNull(_coinbaseClient, "Coinbase client should not be null.");
-                var orderNumber = await _coinbaseClient!.Orders.CreateMarketOrderAsync("BTC-USDC", OrderSide.SELL, "0.0002");
+                var orderNumber = await _coinbaseClient!.Orders.CreateMarketOrderAsync("BTC-USDC", OrderSide.SELL, "0.00001");
                 Assert.IsNotNull(orderNumber, "Order Number should not be null.");
             });
         }
@@ -39,7 +39,7 @@ namespace Coinbase.AdvancedTradeTest
             await ExecuteRateLimitedTest(async () =>
             {
                 Assert.IsNotNull(_coinbaseClient, "Coinbase client should not be null.");
-                var orderNumber = await _coinbaseClient!.Orders.CreateLimitOrderGTCAsync("BTC-USDC", OrderSide.BUY, "0.000035", "10000", true);
+                var orderNumber = await _coinbaseClient!.Orders.CreateLimitOrderGTCAsync("BTC-USDC", OrderSide.BUY, "0.0001", "10000", true);
                 Assert.IsNotNull(orderNumber, "Order number should not be null.");
             });
         }
@@ -51,7 +51,7 @@ namespace Coinbase.AdvancedTradeTest
             await ExecuteRateLimitedTest(async () =>
             {
                 Assert.IsNotNull(_coinbaseClient, "Coinbase client should not be null.");
-                var orderNumber = await _coinbaseClient!.Orders.CreateLimitOrderGTCAsync("BTC-USDC", OrderSide.SELL, "0.000035", "70000", true);
+                var orderNumber = await _coinbaseClient!.Orders.CreateLimitOrderGTCAsync("BTC-USDC", OrderSide.SELL, "0.0001", "75000", true);
                 Assert.IsNotNull(orderNumber, "Order number should not be null.");
             });
         }
@@ -66,7 +66,7 @@ namespace Coinbase.AdvancedTradeTest
             await ExecuteRateLimitedTest(async () =>
             {
                 Assert.IsNotNull(_coinbaseClient, "Coinbase client should not be null.");
-                var orderNumber = await _coinbaseClient!.Orders.CreateLimitOrderGTDAsync("BTC-USDC", OrderSide.BUY, "0.000035", "10000", DateTime.UtcNow.AddDays(1), true);
+                var orderNumber = await _coinbaseClient!.Orders.CreateLimitOrderGTDAsync("BTC-USDC", OrderSide.BUY, "0.0001", "10000", DateTime.UtcNow.AddDays(1), true);
                 Assert.IsNotNull(orderNumber, "Order number should not be null.");
             });
         }
@@ -78,7 +78,7 @@ namespace Coinbase.AdvancedTradeTest
             await ExecuteRateLimitedTest(async () =>
             {
                 Assert.IsNotNull(_coinbaseClient, "Coinbase client should not be null.");
-                var orderNumber = await _coinbaseClient!.Orders.CreateLimitOrderGTDAsync("BTC-USDC", OrderSide.SELL, "0.000035", "70000", DateTime.UtcNow.AddDays(1), true);
+                var orderNumber = await _coinbaseClient!.Orders.CreateLimitOrderGTDAsync("BTC-USDC", OrderSide.SELL, "0.0001", "75000", DateTime.UtcNow.AddDays(1), true);
                 Assert.IsNotNull(orderNumber, "Order number should not be null.");
             });
         }
@@ -92,7 +92,7 @@ namespace Coinbase.AdvancedTradeTest
             await ExecuteRateLimitedTest(async () =>
             {
                 Assert.IsNotNull(_coinbaseClient, "Coinbase client should not be null.");
-                var orderNumber = await _coinbaseClient!.Orders.CreateStopLimitOrderGTCAsync("BTC-USDC", OrderSide.BUY, "0.0001", "69000.00", "68700.00");
+                var orderNumber = await _coinbaseClient!.Orders.CreateStopLimitOrderGTCAsync("BTC-USDC", OrderSide.BUY, "0.0001", "72000.00", "71900.00");
                 Assert.IsNotNull(orderNumber, "Order number should not be null.");
             });
         }
@@ -120,7 +120,7 @@ namespace Coinbase.AdvancedTradeTest
             {
                 Assert.IsNotNull(_coinbaseClient, "Coinbase client should not be null.");
                 var orderNumber = await _coinbaseClient!.Orders.CreateStopLimitOrderGTDAsync(
-                    "BTC-USDC", OrderSide.BUY, "0.0001", "69000.00", "68700.00", DateTime.UtcNow.AddDays(1));
+                    "BTC-USDC", OrderSide.BUY, "0.0001", "72000.00", "71900.00", DateTime.UtcNow.AddDays(1));
                 Assert.IsNotNull(orderNumber, "Order number should not be null.");
             });
         }
@@ -157,7 +157,7 @@ namespace Coinbase.AdvancedTradeTest
             await ExecuteRateLimitedTest(async () =>
             {
                 Assert.IsNotNull(_coinbaseClient, "Coinbase client should not be null.");
-                var orderNumber = await _coinbaseClient!.Orders.CreateSORLimitIOCOrderAsync("BTC-USDC", OrderSide.SELL, "0.000035", "70000");
+                var orderNumber = await _coinbaseClient!.Orders.CreateSORLimitIOCOrderAsync("BTC-USDC", OrderSide.SELL, "0.0001", "70000");
                 Assert.IsNotNull(orderNumber, "Order number should not be null.");
             });
         }

--- a/Coinbase.AdvancedTrade.IntegrationTests/TestOrders.cs
+++ b/Coinbase.AdvancedTrade.IntegrationTests/TestOrders.cs
@@ -73,7 +73,7 @@ namespace Coinbase.AdvancedTradeTest
         {
             await ExecuteRateLimitedTest(async () =>
             {
-                string[] testOrderIds = { "b38ad5a6-6fd5-44db-ad36-196ac426de1a" };
+                string[] testOrderIds = { "b5869167-6109-471c-bb54-3bc287162224" };
                 var result = await _coinbaseClient!.Orders.CancelOrdersAsync(testOrderIds);
 
                 Assert.IsNotNull(result, "Result should not be null.");
@@ -90,10 +90,10 @@ namespace Coinbase.AdvancedTradeTest
         {
             await ExecuteRateLimitedTest(async () =>
             {
-                string existingOrderId = "57f52fa4-7c3e-4a1b-ac67-a3bce72f4086";
+                string existingOrderId = "b5c7bf4f-b00f-4844-b12a-e6725876b0ef";
 
-                string newPrice = "12000.00";
-                string? newSize = "0.000035";
+                string newPrice = "74000.00";
+                string? newSize = "0.0001";
 
                 // Attempt to edit the order
                 var result = await _coinbaseClient!.Orders.EditOrderAsync(existingOrderId, newPrice, newSize);
@@ -110,10 +110,10 @@ namespace Coinbase.AdvancedTradeTest
         {
             await ExecuteRateLimitedTest(async () =>
             {
-                string existingOrderId = "57f52fa4-7c3e-4a1b-ac67-a3bce72f4086";
+                string existingOrderId = "b5c7bf4f-b00f-4844-b12a-e6725876b0ef";
 
-                string newPrice = "12000.00";
-                string? newSize = "0.000035";
+                string newPrice = "74000.00";
+                string? newSize = "0.0001";
 
                 var result = await _coinbaseClient!.Orders.EditOrderPreviewAsync(existingOrderId, newPrice, newSize);
 

--- a/Coinbase.AdvancedTrade.IntegrationTests/TestPublic.cs
+++ b/Coinbase.AdvancedTrade.IntegrationTests/TestPublic.cs
@@ -24,6 +24,15 @@ namespace Coinbase.AdvancedTradeTest
                            ?? throw new InvalidOperationException("API Secret not found");
             _coinbaseClient = new CoinbaseClient(apiKey, apiSecret);
 
+
+            // Coinbase Legacy Keys
+            //var apiKey = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_KEY", EnvironmentVariableTarget.User)
+            //         ?? throw new InvalidOperationException("API Key not found");
+            //var apiSecret = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_SECRET", EnvironmentVariableTarget.User)
+            //           ?? throw new InvalidOperationException("API Secret not found");
+            //_coinbaseClient = new CoinbaseClient(apiKey: apiKey, apiSecret: apiSecret, apiKeyType: ApiKeyType.Legacy);
+
+
             // Setup for public client
             _coinbasePublicClient = new CoinbasePublicClient();
         }

--- a/Coinbase.AdvancedTrade/Coinbase.AdvancedTrade.csproj
+++ b/Coinbase.AdvancedTrade/Coinbase.AdvancedTrade.csproj
@@ -7,9 +7,9 @@
     <PackageProjectUrl>https://github.com/barrywood78/Coinbase.AdvancedTrade</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<AssemblyVersion>1.3</AssemblyVersion>
-	<FileVersion>1.3</FileVersion>
-	<Version>1.3</Version>
+	<AssemblyVersion>1.3.1</AssemblyVersion>
+	<FileVersion>1.3.1</FileVersion>
+	<Version>1.3.1</Version>
 	<Description>An unofficial Coinbase API Wrapper</Description>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 

--- a/Coinbase.AdvancedTrade/CoinbaseClient.cs
+++ b/Coinbase.AdvancedTrade/CoinbaseClient.cs
@@ -45,10 +45,11 @@ namespace Coinbase.AdvancedTrade
         /// <param name="apiKey">The API key for authentication with Coinbase.</param>
         /// <param name="apiSecret">The API secret for authentication with Coinbase.</param>
         /// <param name="websocketBufferSize">The buffer size for WebSocket messages in bytes (Default 5,242,880 bytes/ 5 MB).</param>
-        public CoinbaseClient(string apiKey, string apiSecret, int websocketBufferSize = 5 * 1024 * 1024)
+        /// <param name="apiKeyType">Specifies the type of API key used. This can be either a Legacy key (Depricated) or a Coinbase Developer Platform (CDP) key.</param>
+        public CoinbaseClient(string apiKey, string apiSecret, int websocketBufferSize = 5 * 1024 * 1024, ApiKeyType apiKeyType = ApiKeyType.CoinbaseDeveloperPlatform)
         {
             // Create an instance of CoinbaseAuthenticator with the provided credentials and API key type
-            var authenticator = new CoinbaseAuthenticator(apiKey, apiSecret);
+            var authenticator = new CoinbaseAuthenticator(apiKey, apiSecret, apiKeyType);
 
             // Initialize various service managers with the authenticator
             Accounts = new AccountsManager(authenticator);
@@ -58,7 +59,7 @@ namespace Coinbase.AdvancedTrade
             Public = new PublicManager(authenticator);
 
             // Initialize WebSocketManager for real-time data feed
-            WebSocket = new WebSocketManager("wss://advanced-trade-ws.coinbase.com", apiKey, apiSecret, websocketBufferSize);
+            WebSocket = new WebSocketManager("wss://advanced-trade-ws.coinbase.com", apiKey, apiSecret, websocketBufferSize, apiKeyType);
         }
 
     }

--- a/Coinbase.AdvancedTrade/Enums/ApiKeyType.cs
+++ b/Coinbase.AdvancedTrade/Enums/ApiKeyType.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Coinbase.AdvancedTrade.Enums
+{
+    /// <summary>
+    /// Specifies the type of API key used for authentication with the Coinbase API.
+    /// </summary>
+    public enum ApiKeyType
+    {
+        /// <summary>
+        /// Legacy API key type, which is deprecated and will be removed in future versions.
+        /// </summary>
+        [Obsolete("Legacy API key type is deprecated and will be removed in future versions.")]
+        Legacy,
+
+        /// <summary>
+        /// API key type for the Coinbase Developer Platform.
+        /// </summary>
+        CoinbaseDeveloperPlatform
+    }
+}

--- a/Coinbase.AdvancedTrade/README.md
+++ b/Coinbase.AdvancedTrade/README.md
@@ -2,7 +2,7 @@
 
 This project provides a C# wrapper for the [Coinbase Advanced Trade API](https://docs.cdp.coinbase.com/advanced-trade/docs/welcome/), facilitating interactions with various advanced trading functionalities on Coinbase.
 
-The wrapper now supports only the new Coinbase Developer Platform (CDP) Keys, which utilize JWT for authentication. The legacy API keys option has been removed following Coinbase's update after an extended timeline, effective June 10, 2024. For more details on Coinbase Developer Platform (CDP) Keys, see [Coinbase's documentation](https://docs.cloud.coinbase.com/advanced-trade-api/docs/rest-api-auth#cloud-api-trading-keys).
+The wrapper supports both Coinbase Developer Platform (CDP) Keys and Legacy keys. The new Coinbase Developer Platform (CDP) Keys utilize JWT for authentication. The legacy API keys option has been restored but is deprecated and will be removed in a future release following Coinbase's update and the removal of the ability to create and edit legacy API keys effective June 10, 2024. However, Coinbase will continue to allow existing legacy keys to work for some time. For more details on Coinbase Developer Platform (CDP) Keys, see [Coinbase's documentation](https://docs.cloud.coinbase.com/advanced-trade-api/docs/rest-api-auth#cloud-api-trading-keys).
 
 For Coinbase Developer Platform (CDP) Keys, the `key_name` and `key_secret` are expected to follow this structure as per Coinbase:
 
@@ -87,6 +87,9 @@ Specialized in managing WebSocket communications for real-time updates from the 
   - `Subscriptions`: Get the list of active subscriptions.
 
 # Changelog
+
+## v1.3.1 - 2024-JUN-04
+- **Reverted CoinbaseClient Constructor to Include Legacy API Key Type**: The `CoinbaseClient` constructor again includes the `ApiKeyType` of `Legacy`, but `CoinbaseDeveloperPlatform` is now the default. **This may be a breaking change and can be fixed by supplying the constuctor with an ApiKeyType = Legacy**.
 
 ## v1.3 - 2024-MAY-30
 - **Removed Legacy API Keys**: The wrapper now only supports Coinbase Developer Platform (CDP) API keys due to Coinbase removing legacy keys after an extended timeline, effective June 10, 2024. **This is a breaking change**

--- a/Framework.4.8.TestApp/Program.cs
+++ b/Framework.4.8.TestApp/Program.cs
@@ -20,6 +20,13 @@ namespace Framework._4._8.TestApp
                            ?? throw new InvalidOperationException("API Secret not found");
             coinbaseClient = new CoinbaseClient(apiKey, apiSecret);
 
+            // Coinbase Legacy Keys
+            //var apiKey = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_KEY", EnvironmentVariableTarget.User)
+            //         ?? throw new InvalidOperationException("API Key not found");
+            //var apiSecret = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_SECRET", EnvironmentVariableTarget.User)
+            //           ?? throw new InvalidOperationException("API Secret not found");
+            //coinbaseClient = new CoinbaseClient(apiKey: apiKey, apiSecret: apiSecret, apiKeyType: ApiKeyType.Legacy);
+
             Console.ForegroundColor = ConsoleColor.Green;
             Console.WriteLine(".NET Framework 4.8 Coinbase.AdvancedTrade Test Application");
             Console.ForegroundColor = ConsoleColor.White;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Coinbase API Wrapper for Advanced Trade
 
-This project provides a C# wrapper for the [Coinbase Advanced Trade API](https://docs.cloud.coinbase.com/advanced-trade-api), facilitating interactions with various advanced trading functionalities on Coinbase. The wrapper now supports only the new Coinbase Developer Platform (CDP) Keys, which utilize JWT for authentication. The legacy API keys option has been removed following Coinbase's update effective after an extended timeline, effective June 10, 2024. For more details on Coinbase Developer Platform (CDP) Keys, see [Coinbase's documentation](https://docs.cloud.coinbase.com/advanced-trade-api/docs/rest-api-auth#cloud-api-trading-keys).
+This project provides a C# wrapper for the [Coinbase Advanced Trade API](https://docs.cloud.coinbase.com/advanced-trade-api), facilitating interactions with various advanced trading functionalities on Coinbase. 
+
+The wrapper supports both Coinbase Developer Platform (CDP) Keys and Legacy keys. The new Coinbase Developer Platform (CDP) Keys utilize JWT for authentication. The legacy API keys option has been restored but is deprecated and will be removed in a future release following Coinbase's update and the removal of the ability to create and edit legacy API keys effective June 10, 2024. However, Coinbase will continue to allow existing legacy keys to work for some time. For more details on Coinbase Developer Platform (CDP) Keys, see [Coinbase's documentation](https://docs.cloud.coinbase.com/advanced-trade-api/docs/rest-api-auth#cloud-api-trading-keys).
 
 For Coinbase Developer Platform (CDP) Keys, the `key_name` and `key_secret` are expected to follow this structure as per Coinbase:
 
@@ -96,6 +98,10 @@ The `Coinbase API Wrapper` is accompanied by a suite of tests, ensuring its reli
 - **Test Coverage**: Tests cover key functionalities including (but not limited to) authentication, order management, and WebSocket communication.
 
 # Changelog
+
+## v1.3.1 - 2024-JUN-04
+- **Reverted CoinbaseClient Constructor to Include Legacy API Key Type**: The `CoinbaseClient` constructor again includes the `ApiKeyType` of `Legacy`, but `CoinbaseDeveloperPlatform` is now the default. **This may be a breaking change and can be fixed by supplying the constuctor with an ApiKeyType = Legacy**.
+
 
 ## v1.3 - 2024-MAY-30
 - **Removed Legacy API Keys**: The wrapper now only supports Coinbase Developer Platform (CDP) API keys due to Coinbase removing legacy keys after an extended timeline, effective June 10, 2024. **This is a breaking change**

--- a/WebSocketCandlesTestApp/Program.cs
+++ b/WebSocketCandlesTestApp/Program.cs
@@ -2,19 +2,19 @@
 using Coinbase.AdvancedTrade.Enums;
 bool _isCleanupDone = false;
 
-// Coinbase Legacy API Keys
-//var apiKey = Environment.GetEnvironmentVariable("COINBASE_API_KEY", EnvironmentVariableTarget.User)
-//             ?? throw new InvalidOperationException("API Key not found");
-//var apiSecret = Environment.GetEnvironmentVariable("COINBASE_API_SECRET", EnvironmentVariableTarget.User)
-//               ?? throw new InvalidOperationException("API Secret not found");
-//var coinbaseClient = new CoinbaseClient(apiKey, apiSecret);
-
 // Coinbase Cloud Trading Keys
 var apiKey = Environment.GetEnvironmentVariable("COINBASE_CLOUD_TRADING_API_KEY", EnvironmentVariableTarget.User)
              ?? throw new InvalidOperationException("API Key not found");
 var apiSecret = Environment.GetEnvironmentVariable("COINBASE_CLOUD_TRADING_API_SECRET", EnvironmentVariableTarget.User)
                ?? throw new InvalidOperationException("API Secret not found");
 var coinbaseClient = new CoinbaseClient(apiKey, apiSecret);
+
+// Coinbase Legacy Keys
+//var apiKey = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_KEY", EnvironmentVariableTarget.User)
+//         ?? throw new InvalidOperationException("API Key not found");
+//var apiSecret = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_SECRET", EnvironmentVariableTarget.User)
+//           ?? throw new InvalidOperationException("API Secret not found");
+//var coinbaseClient = new CoinbaseClient(apiKey: apiKey, apiSecret: apiSecret, apiKeyType: ApiKeyType.Legacy);
 
 WebSocketManager? webSocketManager = coinbaseClient.WebSocket;
 

--- a/WebSocketHeartbeatTestApp/Program.cs
+++ b/WebSocketHeartbeatTestApp/Program.cs
@@ -10,6 +10,13 @@ var apiSecret = Environment.GetEnvironmentVariable("COINBASE_CLOUD_TRADING_API_S
                ?? throw new InvalidOperationException("API Secret not found");
 var coinbaseClient = new CoinbaseClient(apiKey, apiSecret);
 
+// Coinbase Legacy Keys
+//var apiKey = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_KEY", EnvironmentVariableTarget.User)
+//         ?? throw new InvalidOperationException("API Key not found");
+//var apiSecret = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_SECRET", EnvironmentVariableTarget.User)
+//           ?? throw new InvalidOperationException("API Secret not found");
+//var coinbaseClient = new CoinbaseClient(apiKey: apiKey, apiSecret: apiSecret, apiKeyType: ApiKeyType.Legacy);
+
 WebSocketManager? webSocketManager = coinbaseClient.WebSocket;
 
 AppDomain.CurrentDomain.ProcessExit += async (s, e) => await CleanupAsync(webSocketManager);

--- a/WebSocketLevel2TestApp/Program.cs
+++ b/WebSocketLevel2TestApp/Program.cs
@@ -10,9 +10,18 @@ var apiKey = Environment.GetEnvironmentVariable("COINBASE_CLOUD_TRADING_API_KEY"
 var apiSecret = Environment.GetEnvironmentVariable("COINBASE_CLOUD_TRADING_API_SECRET", EnvironmentVariableTarget.User)
                ?? throw new InvalidOperationException("API Secret not found");
 
+
+// Coinbase Legacy Keys
+//var apiKey = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_KEY", EnvironmentVariableTarget.User)
+//         ?? throw new InvalidOperationException("API Key not found");
+//var apiSecret = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_SECRET", EnvironmentVariableTarget.User)
+//           ?? throw new InvalidOperationException("API Secret not found");
+
+
 var buffer10MegaBytes = 10 * 1024 * 1024; // 10 MB
 
-var coinbaseClient = new CoinbaseClient(apiKey, apiSecret, buffer10MegaBytes); 
+var coinbaseClient = new CoinbaseClient(apiKey, apiSecret, buffer10MegaBytes);
+//var coinbaseClient = new CoinbaseClient(apiKey: apiKey, apiSecret: apiSecret, websocketBufferSize: buffer10MegaBytes, apiKeyType: ApiKeyType.Legacy);
 
 WebSocketManager? webSocketManager = coinbaseClient.WebSocket;
 

--- a/WebSocketMarketTradesTestApp/Program.cs
+++ b/WebSocketMarketTradesTestApp/Program.cs
@@ -10,6 +10,15 @@ var apiSecret = Environment.GetEnvironmentVariable("COINBASE_CLOUD_TRADING_API_S
                ?? throw new InvalidOperationException("API Secret not found");
 var coinbaseClient = new CoinbaseClient(apiKey, apiSecret);
 
+
+// Coinbase Legacy Keys
+//var apiKey = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_KEY", EnvironmentVariableTarget.User)
+//         ?? throw new InvalidOperationException("API Key not found");
+//var apiSecret = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_SECRET", EnvironmentVariableTarget.User)
+//           ?? throw new InvalidOperationException("API Secret not found");
+//var coinbaseClient = new CoinbaseClient(apiKey: apiKey, apiSecret: apiSecret, apiKeyType: ApiKeyType.Legacy);
+
+
 WebSocketManager? webSocketManager = coinbaseClient.WebSocket;
 
 AppDomain.CurrentDomain.ProcessExit += async (s, e) => await CleanupAsync(webSocketManager);

--- a/WebSocketReconnectionTestApp/Program.cs
+++ b/WebSocketReconnectionTestApp/Program.cs
@@ -11,6 +11,7 @@ class Program
     private static WebSocketManager? webSocketManager = null;
     private static string? apiKey;
     private static string? apiSecret;
+    private static ApiKeyType apiKeyType;
 
     static async Task Main(string[] args)
     {
@@ -19,9 +20,20 @@ class Program
                  ?? throw new InvalidOperationException("API Key not found");
         apiSecret = Environment.GetEnvironmentVariable("COINBASE_CLOUD_TRADING_API_SECRET", EnvironmentVariableTarget.User)
                    ?? throw new InvalidOperationException("API Secret not found");
+        var apiKeyType = ApiKeyType.CoinbaseDeveloperPlatform;
+
+
+        // Coinbase Legacy Keys
+        //apiKey = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_KEY", EnvironmentVariableTarget.User)
+        //         ?? throw new InvalidOperationException("API Key not found");
+        //apiSecret = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_SECRET", EnvironmentVariableTarget.User)
+        //           ?? throw new InvalidOperationException("API Secret not found");
+        //var apiKeyType = ApiKeyType.Legacy;
+
 
         // Initialize the Coinbase client and WebSocket manager
-        coinbaseClient = new CoinbaseClient(apiKey, apiSecret);
+        coinbaseClient = new CoinbaseClient(apiKey: apiKey, apiSecret: apiSecret, apiKeyType: apiKeyType);
+
         webSocketManager = coinbaseClient.WebSocket;
 
         // Handle process exit and Ctrl+C events to ensure cleanup
@@ -187,8 +199,8 @@ class Program
         webSocketManager!.Dispose();
 
         // Create a new WebSocketManager instance using the Coinbase client
-        webSocketManager = new CoinbaseClient(apiKey, apiSecret).WebSocket;
-
+        webSocketManager = new CoinbaseClient(apiKey: apiKey, apiSecret: apiSecret, apiKeyType: apiKeyType).WebSocket;
+    
         // Re-subscribe to WebSocket events with the new WebSocketManager instance
         SubscribeToWebSocketEvents(webSocketManager);
 

--- a/WebSocketStatusTestApp/Program.cs
+++ b/WebSocketStatusTestApp/Program.cs
@@ -10,6 +10,14 @@ var apiSecret = Environment.GetEnvironmentVariable("COINBASE_CLOUD_TRADING_API_S
                ?? throw new InvalidOperationException("API Secret not found");
 var coinbaseClient = new CoinbaseClient(apiKey, apiSecret);
 
+
+// Coinbase Legacy Keys
+//var apiKey = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_KEY", EnvironmentVariableTarget.User)
+//         ?? throw new InvalidOperationException("API Key not found");
+//var apiSecret = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_SECRET", EnvironmentVariableTarget.User)
+//           ?? throw new InvalidOperationException("API Secret not found");
+//var coinbaseClient = new CoinbaseClient(apiKey: apiKey, apiSecret: apiSecret, apiKeyType: ApiKeyType.Legacy);
+
 WebSocketManager? webSocketManager = coinbaseClient.WebSocket;
 
 AppDomain.CurrentDomain.ProcessExit += async (s, e) => await CleanupAsync(webSocketManager);

--- a/WebSocketTickerBatchTestApp/Program.cs
+++ b/WebSocketTickerBatchTestApp/Program.cs
@@ -10,6 +10,14 @@ var apiSecret = Environment.GetEnvironmentVariable("COINBASE_CLOUD_TRADING_API_S
                ?? throw new InvalidOperationException("API Secret not found");
 var coinbaseClient = new CoinbaseClient(apiKey, apiSecret);
 
+
+// Coinbase Legacy Keys
+//var apiKey = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_KEY", EnvironmentVariableTarget.User)
+//         ?? throw new InvalidOperationException("API Key not found");
+//var apiSecret = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_SECRET", EnvironmentVariableTarget.User)
+//           ?? throw new InvalidOperationException("API Secret not found");
+//var coinbaseClient = new CoinbaseClient(apiKey: apiKey, apiSecret: apiSecret, apiKeyType: ApiKeyType.Legacy);
+
 WebSocketManager? webSocketManager = coinbaseClient.WebSocket;
 
 AppDomain.CurrentDomain.ProcessExit += async (s, e) => await CleanupAsync(webSocketManager);

--- a/WebSocketTickerTestApp/Program.cs
+++ b/WebSocketTickerTestApp/Program.cs
@@ -10,6 +10,14 @@ var apiSecret = Environment.GetEnvironmentVariable("COINBASE_CLOUD_TRADING_API_S
                ?? throw new InvalidOperationException("API Secret not found");
 var coinbaseClient = new CoinbaseClient(apiKey, apiSecret);
 
+
+// Coinbase Legacy Keys
+//var apiKey = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_KEY", EnvironmentVariableTarget.User)
+//         ?? throw new InvalidOperationException("API Key not found");
+//var apiSecret = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_SECRET", EnvironmentVariableTarget.User)
+//           ?? throw new InvalidOperationException("API Secret not found");
+//var coinbaseClient = new CoinbaseClient(apiKey: apiKey, apiSecret: apiSecret, apiKeyType: ApiKeyType.Legacy);
+
 WebSocketManager? webSocketManager = coinbaseClient.WebSocket;
 
 AppDomain.CurrentDomain.ProcessExit += async (s, e) => await CleanupAsync(webSocketManager);

--- a/WebSocketUserTestApp/Program.cs
+++ b/WebSocketUserTestApp/Program.cs
@@ -10,6 +10,14 @@ var apiSecret = Environment.GetEnvironmentVariable("COINBASE_CLOUD_TRADING_API_S
                ?? throw new InvalidOperationException("API Secret not found");
 var coinbaseClient = new CoinbaseClient(apiKey, apiSecret);
 
+
+// Coinbase Legacy Keys
+//var apiKey = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_KEY", EnvironmentVariableTarget.User)
+//         ?? throw new InvalidOperationException("API Key not found");
+//var apiSecret = Environment.GetEnvironmentVariable("COINBASE_LEGACY_API_SECRET", EnvironmentVariableTarget.User)
+//           ?? throw new InvalidOperationException("API Secret not found");
+//var coinbaseClient = new CoinbaseClient(apiKey: apiKey, apiSecret: apiSecret, apiKeyType: ApiKeyType.Legacy);
+
 WebSocketManager? webSocketManager = coinbaseClient.WebSocket;
 
 AppDomain.CurrentDomain.ProcessExit += async (s, e) => await CleanupAsync(webSocketManager);


### PR DESCRIPTION
Restored ApiKeyType enum and updated CoinbaseClient constructor to support optional ApiKeyType for both Legacy and CDP keys. Updated test projects accordingly.